### PR TITLE
Default playbook and documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ How to use
 
     git clone git@github.com:mego22/ansible-base.git new-role
     cd new-role/
+    perl -pi -e s,ansible-base,new-role, ./test/integration/default/default.yml
     rm -rf .git
     git init
     git add .

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -2,4 +2,4 @@
 - name: wrapper playbook for kitchen testing
   hosts: all
   roles:
-    - kitchen-ansible
+    - ansible-base


### PR DESCRIPTION
The default playbook intended for test-kitchen was using the incorrect name of the role to test,
and made no reference to updating this when starting new role development.